### PR TITLE
Feature/Improve experience when disbanding a team #1463

### DIFF
--- a/components/dialog/ConfirmationDialogContent.tsx
+++ b/components/dialog/ConfirmationDialogContent.tsx
@@ -62,7 +62,11 @@ export default function ConfirmationDialogContent(props: PropsWithChildren<Confi
       </div>
       <div className="mt-5 sm:mt-8 sm:flex sm:flex-row-reverse gap-x-2">
         <DialogClose onClick={onConfirm} asChild>
-          {confirmBtn || <Button color="primary">{confirmBtnText}</Button>}
+          {confirmBtn || (
+            <Button data-testid="confirmbt-disband-team" color="primary">
+              {confirmBtnText}
+            </Button>
+          )}
         </DialogClose>
         <DialogClose asChild>
           <Button color="secondary">{cancelBtnText}</Button>

--- a/components/team/TeamList.tsx
+++ b/components/team/TeamList.tsx
@@ -33,7 +33,7 @@ export default function TeamList(props: Props) {
 
   return (
     <div>
-      <ul className="mb-2 bg-white border divide-y rounded divide-neutral-200">
+      <ul className="mb-2 bg-white border divide-y rounded divide-neutral-200" data-testid="teams">
         {props.teams.map((team) => (
           <TeamListItem
             key={team?.id as number}

--- a/components/team/TeamSettingsRightSidebar.tsx
+++ b/components/team/TeamSettingsRightSidebar.tsx
@@ -26,8 +26,12 @@ export default function TeamSettingsRightSidebar(props: { team: TeamWithMembers;
 
   const deleteTeamMutation = trpc.useMutation("viewer.teams.delete", {
     async onSuccess() {
-      await utils.invalidateQueries(["viewer.teams.get"]);
+      await utils.invalidateQueries(["viewer.teams.list"]);
+      await router.push("/settings/teams");
       showToast(t("your_team_updated_successfully"), "success");
+    },
+    onError: (err) => {
+      showToast(err.message, "error");
     },
   });
   const acceptOrLeaveMutation = trpc.useMutation("viewer.teams.acceptOrLeave", {
@@ -81,6 +85,7 @@ export default function TeamSettingsRightSidebar(props: { team: TeamWithMembers;
           <Dialog>
             <DialogTrigger asChild>
               <LinkIconButton
+                data-testid="disband-team"
                 onClick={(e) => {
                   e.stopPropagation();
                 }}

--- a/pages/settings/teams.tsx
+++ b/pages/settings/teams.tsx
@@ -61,6 +61,7 @@ export default function Teams() {
           <Button
             disabled={isFreePlan}
             type="button"
+            data-testid="new-team"
             className="btn btn-white"
             onClick={() => setShowCreateTeamModal(true)}>
             <PlusIcon className="group-hover:text-black text-gray-700 w-3.5 h-3.5 mr-2 inline-block" />

--- a/playwright/team-disband.test.ts
+++ b/playwright/team-disband.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test";
+import { randomString } from "../lib/random";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/settings/teams");
+  await page.waitForSelector('[data-testid=teams]');
+});
+
+test.describe('owner user', () => {
+
+  test.use({ storageState: "playwright/artifacts/teamproStorageState.json" });
+
+  test('can disband a team', async ({ page }) => {
+    const nonce = randomString(5);
+    const teamName = `Team ${nonce}`;
+    await page.click("[data-testid=new-team]");
+    await page.fill("[name=name]", teamName);
+    await page.click('[type=submit]');
+    await expect(page.locator(`text='${teamName}'`)).toBeVisible();
+
+    const $teams = await page.$$('[data-testid=teams] > *');
+    expect($teams.length).toBeGreaterThanOrEqual(0);
+    const [$first] = $teams;
+    $first.click();
+
+    await page.click("[data-testid=disband-team]");
+    await page.click("[data-testid=confirmbt-disband-team]");
+    await expect(page).toHaveURL("/settings/teams");
+  });
+});
+


### PR DESCRIPTION
## What does this PR do?

![improve](https://user-images.githubusercontent.com/97113254/153219656-7c7e1392-1d25-49ae-a393-01d0d51f6409.gif)

This PR fixes an error that is thrown after a user disbands a team in the team details screen and redirects to the settings/teams route. Also includes an E2E test with Playwright.

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes # [1463 ](https://github.com/calcom/cal.com/issues/1463) 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

`yarn playwright test playwright/team-disband.test.ts`

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code and corrected any misspellings
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
