### PR TITLE
Improve experience when disbanding a team - Playwirght test #1463

### DIFF
--- a/components/dialog/ConfirmationDialogContent.tsx
+++ b/components/dialog/ConfirmationDialogContent.tsx
@@ -62,7 +62,11 @@ export default function ConfirmationDialogContent(props: PropsWithChildren<Confi
       </div>
       <div className="mt-5 gap-x-2 sm:mt-8 sm:flex sm:flex-row-reverse">
         <DialogClose onClick={onConfirm} asChild>
-          {confirmBtn || <Button color="primary">{confirmBtnText}</Button>}
+          {confirmBtn || (
+            <Button data-testid="confirmbt-disband-team" color="primary">
+              {confirmBtnText}
+            </Button>
+          )}
         </DialogClose>
         <DialogClose asChild>
           <Button color="secondary">{cancelBtnText}</Button>

--- a/components/team/TeamList.tsx
+++ b/components/team/TeamList.tsx
@@ -33,7 +33,7 @@ export default function TeamList(props: Props) {
 
   return (
     <div>
-      <ul className="mb-2 divide-y divide-neutral-200 rounded border bg-white">
+      <ul className="mb-2 divide-y divide-neutral-200 rounded border bg-white" data-testid="teams">
         {props.teams.map((team) => (
           <TeamListItem
             key={team?.id as number}

--- a/components/team/TeamSettingsRightSidebar.tsx
+++ b/components/team/TeamSettingsRightSidebar.tsx
@@ -81,6 +81,7 @@ export default function TeamSettingsRightSidebar(props: { team: TeamWithMembers;
           <Dialog>
             <DialogTrigger asChild>
               <LinkIconButton
+                data-testid="disband-team"
                 onClick={(e) => {
                   e.stopPropagation();
                 }}

--- a/pages/settings/teams.tsx
+++ b/pages/settings/teams.tsx
@@ -61,6 +61,7 @@ export default function Teams() {
         <div className={classNames("my-4 flex justify-end", isFreePlan && "opacity-50")}>
           <Button
             disabled={isFreePlan}
+            data-testid="new-team"
             type="button"
             className="btn btn-white"
             onClick={() => setShowCreateTeamModal(true)}>

--- a/playwright/team-disband.test.ts
+++ b/playwright/team-disband.test.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+import { randomString } from "../lib/random";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/settings/teams");
+  await page.waitForSelector('[data-testid=teams]');
+});
+
+test.describe('owner user', () => {
+
+  test.use({ storageState: "playwright/artifacts/trialStorageState.json" });
+
+  test('can disband a team', async ({ page }) => {
+    // Creata a new team
+    const nonce = randomString(5);
+    const teamName = `Team ${nonce}`;
+    await page.locator("[data-testid=new-team]").click();
+    await page.fill("[name=name]", teamName);
+    await page.click('[type=submit]');
+    await expect(page.locator(`text='${teamName}'`)).toBeVisible();
+
+    // select created team
+    const $teams = await page.$$('[data-testid=teams] > *');
+    expect($teams.length).toBeGreaterThanOrEqual(0);
+    const [ , $second] = $teams;
+    $second.click();
+
+    await page.click("[data-testid=disband-team]");
+    await page.click("[data-testid=confirmbt-disband-team]");
+
+    await expect(page).toHaveURL("/settings/teams", {timeout: 2000});
+  });
+});

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -243,7 +243,7 @@ async function main() {
     ],
   });
 
-  await createUserAndEventType({
+  const trialUserTeam = await createUserAndEventType({
     user: {
       email: "trial@example.com",
       password: "trial",
@@ -340,6 +340,19 @@ async function main() {
       {
         id: freeUserTeam.id,
         username: freeUserTeam.name || "Unknown",
+      },
+    ]
+  );
+
+  await createTeamAndAddUsers(
+    {
+      name: "Seeded Trial Team",
+      slug: "seeded-trial-team",
+    },
+    [
+      {
+        id: trialUserTeam.id,
+        username: trialUserTeam.name || "Unknown",
       },
     ]
   );


### PR DESCRIPTION
## What does this PR do?

Add a playwright test to check if after disbanding a team users are redirected to the settings/teams URI. The test uses a trial user to check it (with pro user you need to set up the api keys for Stripe), also add a seed to create a team in trial user then maybe you should update the seeds.

`yarn db-seed`

Test: [#14]


<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

Fixes #14 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How should this be tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration -->

`yarn test-playwright playwright/team-disband.test.ts`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code and corrected any misspellings
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
